### PR TITLE
Tell dzil that git-stitch-repo should be installed

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -16,6 +16,9 @@ match    = \.patch$
 match    = mess/.*
 match    = cover_db
 
+[ExecDir]
+dir = script
+
 [AutoPrereqs]
 
 [ReportVersions::Tiny]


### PR DESCRIPTION
The `Makefile.PL` in the distro on CPAN says `"EXE_FILES" => []`. No wonder – you forgot to declare your scripts directory, you clod. :smile:
